### PR TITLE
feat: add Supabase-backed story queries

### DIFF
--- a/vaulter_starter/app/page.tsx
+++ b/vaulter_starter/app/page.tsx
@@ -2,7 +2,12 @@ import Link from 'next/link'
 import { listStories } from '@/lib/db'
 
 export default async function HomePage() {
-  const stories = await listStories({ limit: 12 })
+  let stories = []
+  try {
+    stories = await listStories({ limit: 12 })
+  } catch (err) {
+    console.error('Failed to load stories', err)
+  }
   return (
     <div className="space-y-6">
       <header className="space-y-2">

--- a/vaulter_starter/app/story/[slug]/page.tsx
+++ b/vaulter_starter/app/story/[slug]/page.tsx
@@ -6,7 +6,12 @@ import Markdown from 'react-markdown'
 type Params = { slug: string }
 
 export default async function StoryPage({ params }: { params: Params }) {
-  const story = await getStoryBySlug(params.slug)
+  let story = null
+  try {
+    story = await getStoryBySlug(params.slug)
+  } catch (err) {
+    console.error('Failed to load story', err)
+  }
   if (!story) return notFound()
   return (
     <article className="prose dark:prose-invert max-w-none">

--- a/vaulter_starter/lib/supabase.ts
+++ b/vaulter_starter/lib/supabase.ts
@@ -1,0 +1,9 @@
+import { createClient } from '@supabase/supabase-js'
+
+export const supabase = createClient(
+  process.env.SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE!,
+  {
+    auth: { persistSession: false }
+  }
+)


### PR DESCRIPTION
## Summary
- add Supabase client using service role credentials
- run story helpers against Supabase tables
- handle story query failures in server components

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689acefb2360832d933d05195705d482