### PR TITLE
Add Vitest unit tests and npm test script

### DIFF
--- a/vaulter_starter/.gitignore
+++ b/vaulter_starter/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/vaulter_starter/README.md
+++ b/vaulter_starter/README.md
@@ -9,6 +9,10 @@ Mobile‑first automated local‑news site (Next.js App Router). This starter in
    npm run dev
    ```
 3. Visit http://localhost:3000 — you should see a seeded story.
+4. Run unit tests:
+   ```bash
+   npm test
+   ```
 
 ## Deploy to Vercel
 - Import this repo into Vercel.

--- a/vaulter_starter/lib/__tests__/ai.test.ts
+++ b/vaulter_starter/lib/__tests__/ai.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi } from 'vitest'
+import { generateStory } from '../ai'
+import type { RawItem } from '../ingest'
+
+vi.mock('openai', () => ({ OpenAI: vi.fn() }))
+
+describe('generateStory', () => {
+  const raw: RawItem = {
+    url: 'https://example.com',
+    title: 'Sample',
+    text: 'x'.repeat(250),
+    published_at: '2024-01-01',
+    source: 'Test'
+  }
+
+  it('validates and returns a slug', async () => {
+    const result = await generateStory(raw)
+    expect(result.slug).toBe('wsdot-adjusts-ferry-schedule-during-maintenance')
+    expect(result.ai_body_md.length).toBeGreaterThan(200)
+    expect(result.ai_title.length).toBeLessThanOrEqual(75)
+  })
+})

--- a/vaulter_starter/lib/__tests__/ingest.test.ts
+++ b/vaulter_starter/lib/__tests__/ingest.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest'
+import { fetchFeeds, selectCandidates, type RawItem } from '../ingest'
+
+describe('selectCandidates', () => {
+  it('returns the highest ranked item', async () => {
+    const items: RawItem[] = [
+      { url: '1', title: 'First', text: 'A' },
+      { url: '2', title: 'Second', text: 'B' }
+    ]
+    const selected = await selectCandidates(items)
+    expect(selected).toHaveLength(1)
+    expect(selected[0].url).toBe('1')
+  })
+})
+
+describe('fetchFeeds', () => {
+  it('fetches items with required fields', async () => {
+    const items = await fetchFeeds()
+    expect(items.length).toBeGreaterThan(0)
+    const item = items[0]
+    expect(item).toHaveProperty('url')
+    expect(item).toHaveProperty('title')
+    expect(item).toHaveProperty('text')
+  })
+})

--- a/vaulter_starter/lib/__tests__/publish.test.ts
+++ b/vaulter_starter/lib/__tests__/publish.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('@/lib/db', () => ({
+  insertStory: vi.fn(async (s) => s)
+}))
+
+import { publishStory } from '../publish'
+import { insertStory } from '@/lib/db'
+import type { Generated } from '../ai'
+
+describe('publishStory', () => {
+  it('writes a story via Supabase client', async () => {
+    const g: Generated & { slug: string } = {
+      slug: 'test-slug',
+      ai_title: 'T',
+      ai_subtitle: 'S',
+      ai_body_md: 'a'.repeat(210),
+      bottom_line: 'bottom line',
+      image_alt: 'alt text'
+    }
+    const result = await publishStory(g)
+    expect(insertStory).toHaveBeenCalledOnce()
+    expect(result.slug).toBe('test-slug')
+  })
+})

--- a/vaulter_starter/package.json
+++ b/vaulter_starter/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "next lint",
     "seed": "node scripts/seed.mjs",
-    "cron:run": "node scripts/cron.mjs"
+    "cron:run": "node scripts/cron.mjs",
+    "test": "vitest run"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.45.4",

--- a/vaulter_starter/vitest.config.ts
+++ b/vaulter_starter/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config'
+import path from 'path'
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, '.')
+    }
+  },
+  test: {
+    environment: 'node'
+  }
+})


### PR DESCRIPTION
## Summary
- add Vitest configuration and unit tests for ingest ranking, AI schema validation, and publish database writes
- mock OpenAI and Supabase clients in tests
- document `npm test` script in package.json and README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689acef5678c832db02195ad3214d87e