### PR TITLE
Ensure unique slugs and persist story metadata

### DIFF
--- a/vaulter_starter/lib/ai.ts
+++ b/vaulter_starter/lib/ai.ts
@@ -7,6 +7,10 @@ export type Generated = {
   ai_body_md: string
   bottom_line: string
   image_alt: string
+  image_url: string
+  tags: string[]
+  region: string
+  category: string
 }
 
 const schema = z.object({
@@ -14,7 +18,11 @@ const schema = z.object({
   ai_subtitle: z.string().max(140),
   ai_body_md: z.string().min(200),
   bottom_line: z.string().min(10),
-  image_alt: z.string().min(10)
+  image_alt: z.string().min(10),
+  image_url: z.string().url(),
+  tags: z.array(z.string()),
+  region: z.string(),
+  category: z.string()
 })
 
 export async function generateStory(item: RawItem): Promise<Generated & { slug: string }> {
@@ -24,7 +32,11 @@ export async function generateStory(item: RawItem): Promise<Generated & { slug: 
     ai_subtitle: 'Agency cites vessel maintenance; riders advised to check updated sailings.',
     ai_body_md: `> Note: Demo content. Replace with AI output.\n\n${item.text}\n\n**Key details**\n- Source: ${item.source}\n- Published: ${item.published_at}`,
     bottom_line: 'Expect temporary delays; verify sailings before you go.',
-    image_alt: 'Washington State ferry at dock during sunset'
+    image_alt: 'Washington State ferry at dock during sunset',
+    image_url: 'https://example.com/ferry.jpg',
+    tags: ['transportation', 'ferry'],
+    region: 'WA',
+    category: 'transportation'
   }
   const parsed = schema.parse(mock)
   const slug = parsed.ai_title.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '')

--- a/vaulter_starter/lib/db.ts
+++ b/vaulter_starter/lib/db.ts
@@ -7,6 +7,9 @@ type Story = {
   ai_subtitle: string
   ai_body_md: string
   image_url?: string
+  tags?: string[]
+  region?: string
+  category?: string
   published_at?: string
   created_at: string
   bottom_line?: string
@@ -20,6 +23,15 @@ export async function getStoryBySlug(slug: string) {
   return mem.stories.find(s => s.slug === slug || s.id === slug)
 }
 export async function insertStory(s: Story) {
+  if (s.slug) {
+    const base = s.slug
+    let candidate = base
+    let i = 1
+    while (mem.stories.some(story => story.slug === candidate)) {
+      candidate = `${base}-${i++}`
+    }
+    s.slug = candidate
+  }
   mem.stories.unshift(s)
   return s
 }

--- a/vaulter_starter/lib/publish.ts
+++ b/vaulter_starter/lib/publish.ts
@@ -1,5 +1,6 @@
 import { insertStory } from '@/lib/db'
 import type { Generated } from '@/lib/ai'
+import { revalidatePath } from 'next/cache'
 
 export async function publishStory(g: Generated & { slug: string }) {
   const row = await insertStory({
@@ -8,10 +9,17 @@ export async function publishStory(g: Generated & { slug: string }) {
     ai_title: g.ai_title,
     ai_subtitle: g.ai_subtitle,
     ai_body_md: g.ai_body_md,
-    image_url: '',
+    image_url: g.image_url,
+    tags: g.tags,
+    region: g.region,
+    category: g.category,
     published_at: new Date().toISOString(),
     created_at: new Date().toISOString(),
     bottom_line: g.bottom_line
   })
+  revalidatePath('/')
+  if (row.slug) {
+    revalidatePath(`/story/${row.slug}`)
+  }
   return row
 }

--- a/vaulter_starter/scripts/seed.mjs
+++ b/vaulter_starter/scripts/seed.mjs
@@ -6,7 +6,10 @@ const demo = [{
   ai_title: 'WSDOT adjusts ferry schedule during maintenance',
   ai_subtitle: 'Agency cites vessel maintenance; riders advised to check updated sailings.',
   ai_body_md: 'Demo content body.',
-  image_url: '',
+  image_url: 'https://example.com/ferry.jpg',
+  tags: ['transportation', 'ferry'],
+  region: 'WA',
+  category: 'transportation',
   published_at: new Date().toISOString(),
   created_at: new Date().toISOString(),
   bottom_line: 'Expect temporary delays; verify sailings before you go.'


### PR DESCRIPTION
## Summary
- ensure `insertStory` appends a numeric suffix when a slug conflict occurs
- store tags, region, category, and image URL for stories
- revalidate the home page and individual story path after publishing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689acef8d618832db919b3d525050676