### PR TITLE
feat: generate stories with OpenAI

### DIFF
--- a/vaulter_starter/.env.example
+++ b/vaulter_starter/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=

--- a/vaulter_starter/.gitignore
+++ b/vaulter_starter/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+package-lock.json
+.env
+.env.local
+.env.*.local

--- a/vaulter_starter/README.md
+++ b/vaulter_starter/README.md
@@ -14,6 +14,7 @@ Mobile‑first automated local‑news site (Next.js App Router). This starter in
 - Import this repo into Vercel.
 - Add a **Cron Job** in Vercel (Settings → Cron Jobs) to POST `/api/cron/run` every 30 minutes.
 - Add environment variables later when you wire Supabase + OpenAI.
+- Set `OPENAI_API_KEY` in your environment when enabling OpenAI features.
 
 ## Next Steps
 - Replace the in‑memory DB with Supabase. See `supabase/migrations/` and `supabase/README.md`.

--- a/vaulter_starter/app/story/[slug]/page.tsx
+++ b/vaulter_starter/app/story/[slug]/page.tsx
@@ -13,7 +13,7 @@ export default async function StoryPage({ params }: { params: Params }) {
       <h1>{story.ai_title}</h1>
       <p className="lead">{story.ai_subtitle}</p>
       {story.image_url ? (
-        <Image src={story.image_url} alt={story.ai_title} width={1200} height={630} className="rounded-xl border" />
+        <Image src={story.image_url} alt={story.image_alt ?? story.ai_title} width={1200} height={630} className="rounded-xl border" />
       ) : null}
       <Markdown>{story.ai_body_md}</Markdown>
       <p className="text-sm opacity-60 mt-6">Bottom line: {story.bottom_line ?? '—'}</p>

--- a/vaulter_starter/lib/ai.ts
+++ b/vaulter_starter/lib/ai.ts
@@ -1,32 +1,45 @@
+import OpenAI from 'openai'
 import { z } from 'zod'
 import type { RawItem } from './ingest'
+
+const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
 
 export type Generated = {
   ai_title: string
   ai_subtitle: string
   ai_body_md: string
+  tags: string[]
   bottom_line: string
   image_alt: string
+  image_url: string
 }
 
 const schema = z.object({
   ai_title: z.string().max(75),
   ai_subtitle: z.string().max(140),
   ai_body_md: z.string().min(200),
+  tags: z.array(z.string().max(30)).min(1).max(5),
   bottom_line: z.string().min(10),
   image_alt: z.string().min(10)
 })
 
 export async function generateStory(item: RawItem): Promise<Generated & { slug: string }> {
-  // Placeholder: in production, call OpenAI with neutrality prompt.
-  const mock: Generated = {
-    ai_title: 'WSDOT adjusts ferry schedule during maintenance',
-    ai_subtitle: 'Agency cites vessel maintenance; riders advised to check updated sailings.',
-    ai_body_md: `> Note: Demo content. Replace with AI output.\n\n${item.text}\n\n**Key details**\n- Source: ${item.source}\n- Published: ${item.published_at}`,
-    bottom_line: 'Expect temporary delays; verify sailings before you go.',
-    image_alt: 'Washington State ferry at dock during sunset'
-  }
-  const parsed = schema.parse(mock)
+  const prompt = `You are a neutral local news writer. Using the source text, craft a concise and impartial brief.\nSource: ${item.source}\nPublished: ${item.published_at}\nText: ${item.text}\nReturn JSON with keys: ai_title, ai_subtitle, ai_body_md, tags, bottom_line, image_alt.`
+
+  const parsed = await client.responses.parse({
+    model: 'gpt-4o-mini',
+    input: prompt,
+    temperature: 0.2,
+    schema
+  })
+
+  const img = await client.images.generate({
+    model: 'gpt-image-1',
+    prompt: parsed.image_alt,
+    size: '1024x1024'
+  })
+  const image_url = img.data[0]?.url ?? ''
+
   const slug = parsed.ai_title.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '')
-  return { ...parsed, slug }
+  return { ...parsed, image_url, slug }
 }

--- a/vaulter_starter/lib/db.ts
+++ b/vaulter_starter/lib/db.ts
@@ -7,6 +7,8 @@ type Story = {
   ai_subtitle: string
   ai_body_md: string
   image_url?: string
+  image_alt?: string
+  tags?: string[]
   published_at?: string
   created_at: string
   bottom_line?: string

--- a/vaulter_starter/lib/publish.ts
+++ b/vaulter_starter/lib/publish.ts
@@ -8,7 +8,9 @@ export async function publishStory(g: Generated & { slug: string }) {
     ai_title: g.ai_title,
     ai_subtitle: g.ai_subtitle,
     ai_body_md: g.ai_body_md,
-    image_url: '',
+    image_url: g.image_url,
+    image_alt: g.image_alt,
+    tags: g.tags,
     published_at: new Date().toISOString(),
     created_at: new Date().toISOString(),
     bottom_line: g.bottom_line

--- a/vaulter_starter/scripts/seed.mjs
+++ b/vaulter_starter/scripts/seed.mjs
@@ -7,6 +7,8 @@ const demo = [{
   ai_subtitle: 'Agency cites vessel maintenance; riders advised to check updated sailings.',
   ai_body_md: 'Demo content body.',
   image_url: '',
+  image_alt: 'Demo image alt text',
+  tags: ['demo'],
   published_at: new Date().toISOString(),
   created_at: new Date().toISOString(),
   bottom_line: 'Expect temporary delays; verify sailings before you go.'


### PR DESCRIPTION
## Summary
- initialize OpenAI client using `OPENAI_API_KEY`
- generate story copy and tags with neutrality prompt and Zod schema
- produce image URL via OpenAI Images API and store tags/alt text

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (prompts for ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_e_689acef815fc832da6dc4b90ded9cc88